### PR TITLE
Add additional functions such as `retain`, `replace_once` and `remove_once`

### DIFF
--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -1098,6 +1098,24 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
         self.rebuild_tail(start);
     }
 
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all elements `e` for which `f(&e)` returns
+    /// `false`. The elements are visited in unsorted (and unspecified) order.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use std::collections::BinaryHeap;
+    ///
+    /// let mut heap = BinaryHeap::from([-10, -5, 1, 2, 4, 13]);
+    ///
+    /// heap.retain(|x| x % 2 == 0); // only keep even numbers
+    ///
+    /// assert_eq!(heap.into_sorted_vec(), [-10, 2, 4])
+    /// ```
     // #[stable(feature = "binary_heap_retain", since = "1.70.0")]
     pub fn retain<F>(&mut self, mut f: F)
     where

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -1179,6 +1179,50 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
             i += 1;
         }
     }
+
+    /// Repalce the first element specified by the predicate with the given
+    /// `item`.
+    ///
+    /// In other words, replace the first element `e` for which `f(&e)` returns
+    /// `true` with element `item`. The elements are visited in unsorted
+    /// (and unspecified) order.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use binary_heap_plus::BinaryHeap;
+    ///
+    /// let mut heap = BinaryHeap::from([-10, -5, 1, 2, 4, 13]);
+    ///
+    /// heap.replace_once(|x| *x == -5, -3); // replace -5 with -3
+    /// heap.replace_once(|x| *x == 2, 13); // replace 2 with 13
+    ///
+    /// assert_eq!(heap.into_sorted_vec(), [-10, -3, 1, 4, 13, 13])
+    /// ```
+    pub fn replace_once<F>(&mut self, mut f: F, item: T)
+    where
+        F: FnMut(&T) -> bool,
+    {
+        let mut guard = RebuildOnDrop {
+            rebuild_from: self.len(),
+            heap: self,
+        };
+        let mut i = 0;
+
+        for e in &mut guard.heap.data {
+            let replace = f(e);
+
+            if replace && i < guard.rebuild_from {
+                guard.rebuild_from = i;
+                *e = item;
+                return;
+            }
+
+            i += 1;
+        }
+    }
 }
 
 impl<T, C> BinaryHeap<T, C> {

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -1177,7 +1177,7 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
         }
     }
 
-    /// Repalce the first element specified by the predicate with the given
+    /// Replaces the first element specified by the predicate with the given
     /// `item`.
     ///
     /// In other words, replace the first element `e` for which `f(&e)` returns

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -1167,10 +1167,10 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
         };
         let mut i = 0;
 
-        for e in &guard.heap.data {
+        for (i, e) in guard.heap.data.iter().enumerate() {
             let remove = f(e);
 
-            if remove && i < guard.rebuild_from {
+            if remove {
                 guard.rebuild_from = i;
                 guard.heap.data.swap_remove(i);
                 return;

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -1165,7 +1165,6 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
             rebuild_from: self.len(),
             heap: self,
         };
-        let mut i = 0;
 
         for (i, e) in guard.heap.data.iter().enumerate() {
             let remove = f(e);
@@ -1175,8 +1174,6 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
                 guard.heap.data.swap_remove(i);
                 return;
             }
-
-            i += 1;
         }
     }
 
@@ -1209,18 +1206,15 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
             rebuild_from: self.len(),
             heap: self,
         };
-        let mut i = 0;
 
-        for e in &mut guard.heap.data {
+        for (i, e) in guard.heap.data.iter_mut().enumerate() {
             let replace = f(e);
 
-            if replace && i < guard.rebuild_from {
+            if replace {
                 guard.rebuild_from = i;
                 *e = item;
                 return;
             }
-
-            i += 1;
         }
     }
 }

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -1138,6 +1138,47 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
             keep
         });
     }
+
+    /// Removes the first element specified by the predicate.
+    ///
+    /// In other words, remove the first element `e` for which `f(&e)` returns
+    /// `true`. The elements are visited in unsorted (and unspecified) order.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use binary_heap_plus::BinaryHeap;
+    ///
+    /// let mut heap = BinaryHeap::from([-10, -5, 1, 2, 4, 13]);
+    ///
+    /// heap.remove_once(|x| *x == -5); // remove -5
+    ///
+    /// assert_eq!(heap.into_sorted_vec(), [-10, 1, 2, 4, 13])
+    /// ```
+    pub fn remove_once<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&T) -> bool,
+    {
+        let mut guard = RebuildOnDrop {
+            rebuild_from: self.len(),
+            heap: self,
+        };
+        let mut i = 0;
+
+        for e in &guard.heap.data {
+            let remove = f(e);
+
+            if remove && i < guard.rebuild_from {
+                guard.rebuild_from = i;
+                guard.heap.data.swap_remove(i);
+                return;
+            }
+
+            i += 1;
+        }
+    }
 }
 
 impl<T, C> BinaryHeap<T, C> {


### PR DESCRIPTION
This PR add the following functions to `BinaryHeap`:

- `retain`, which is merely copy paste from std::collections::BinaryHeap ([here](https://doc.rust-lang.org/src/alloc/collections/binary_heap/mod.rs.html#918-936)), with minor modification to make it works in this crate.
- `replace_once`, to replace the first entry that match the predicate with the provided entry.
- `remove_once`, to remove the first entry that match the predicate.
